### PR TITLE
updated srcset override

### DIFF
--- a/public/class-sua-public.php
+++ b/public/class-sua-public.php
@@ -100,9 +100,7 @@ if (!class_exists('SimpleUserAvatar_Public')) {
       $attachment_srcset = wp_get_attachment_image_srcset($attachment_id);
 
       // Override WordPress srcset
-      if($attachment_srcset !== false) {
-        $avatar = preg_replace('/srcset=("|\').*?("|\')/', "srcset='{$attachment_srcset}'", $avatar);
-      }
+      $avatar = preg_replace('/srcset=("|\').*?("|\')/', $attachment_srcset !== false ? "srcset='{$attachment_srcset}'" : "", $avatar);
 
       return $avatar;
 


### PR DESCRIPTION
In some cases, wp_get_attachment_image_srcset will not be returned thus while the src attribute is overwritten, the srcset attribute is not and some browsers still display the gravatar profile picture.

This pull request will clear the srcset in case wp_get_attachment_image_srcset is returning false.